### PR TITLE
Limit coordinates to four decimals

### DIFF
--- a/lib/Weather/YR.pm
+++ b/lib/Weather/YR.pm
@@ -28,8 +28,8 @@ our $VERSION = '0.44';
 
     my $yr = Weather::YR->new(
         lang => 'en',
-        lat  => 63.590833,
-        lon  => 10.741389,
+        lat  => 63.5908,
+        lon  => 10.7414,
         tz   => DateTime::TimeZone->new( name => 'Europe/Oslo' ),
         ua   => LWP::UserAgent->new(
             agent => 'AcmeWeatherApp/0.9 support@example.com',

--- a/lib/Weather/YR/Base.pm
+++ b/lib/Weather/YR/Base.pm
@@ -126,6 +126,19 @@ sub date_to_datetime {
     return $date;
 }
 
+sub lat_as_string {
+    my $self = shift;
+
+    my $lat = $self->lat;
+    return defined $lat ? sprintf "%.4f", $lat : '';
+}
+
+sub lon_as_string {
+    my $self = shift;
+
+    my $lon = $self->lon;
+    return defined $lon ? sprintf "%.4f", $lon : '';
+}
 
 __PACKAGE__->meta->make_immutable;
 

--- a/lib/Weather/YR/LocationForecast.pm
+++ b/lib/Weather/YR/LocationForecast.pm
@@ -54,8 +54,8 @@ Returns the URL to YR.no's location forecast service. This is handy if you
 want to retrieve the XML from YR.no yourself;
 
     my $yr = Weather::YR->new(
-        lat => 63.590833,
-        lon => 10.741389,
+        lat => 63.5908,
+        lon => 10.7414,
     );
 
     my $url = $yr->location_forecast->url;
@@ -76,7 +76,11 @@ sub _build_url {
 
     my $url = $self->service_url->clone;
     $url->path ( '/weatherapi/locationforecast/2.0/classic' );
-    $url->query( lat => $self->lat, lon => $self->lon, altitude => $self->msl );
+    $url->query(
+        lat      => $self->lat_as_string,
+        lon      => $self->lon_as_string,
+        altitude => $self->msl
+    );
 
     return $url;
 }

--- a/lib/Weather/YR/TextLocation.pm
+++ b/lib/Weather/YR/TextLocation.pm
@@ -15,7 +15,11 @@ sub _build_url {
 
     my $url = $self->service_url->clone;
     $url->path ( '/weatherapi/textlocation/1.0/' );
-    $url->query( latitude => $self->lat, longitude => $self->lon, language => $self->lang );
+    $url->query(
+        latitude  => $self->lat_as_string,
+        longitude => $self->lon_as_string,
+        language  => $self->lang
+    );
 
     return $url;
 }

--- a/t/10-basic.t
+++ b/t/10-basic.t
@@ -16,7 +16,7 @@ my $yr = Weather::YR->new(
 );
 
 # Make sure that the API URLs are correct.
-is( $yr->location_forecast->url, $yr->service_url->to_string . '/weatherapi/locationforecast/2.0/classic?lat=63.590833&lon=10.741389&altitude=0', 'URL for location forecast is OK.' );
+is( $yr->location_forecast->url, $yr->service_url->to_string . '/weatherapi/locationforecast/2.0/classic?lat=63.5908&lon=10.7414&altitude=0', 'URL for location forecast is OK.' );
 
 # The End
 done_testing;


### PR DESCRIPTION
According to https://api.met.no/doc/TermsOfService#traffic the latitude and longitude need to be truncated to four decimals. This pull requests adds the methods `lat_as_string` and `lon_as_string` to `Weather::YR::Base`.